### PR TITLE
misc: change default config directory to /etc/connector

### DIFF
--- a/connector-definition/.hasura-connector/Dockerfile
+++ b/connector-definition/.hasura-connector/Dockerfile
@@ -1,3 +1,3 @@
 FROM ghcr.io/hasura/ndc-rest:{{VERSION}}
 
-COPY ./config /config
+COPY ./config /etc/connector

--- a/connector-definition/.hasura-connector/connector-metadata.yaml
+++ b/connector-definition/.hasura-connector/connector-metadata.yaml
@@ -6,5 +6,5 @@ commands: {}
 dockerComposeWatch:
   # copy config files into the existing container and restart it
   - path: ./config
-    target: /config
+    target: /etc/connector
     action: sync+restart


### PR DESCRIPTION
Change the default config directory to `/etc/connector` ([deployment spec](https://github.com/hasura/ndc-hub/blob/main/rfcs/0000-deployment.md#proposal))