### PR TITLE
fix: avoid modifying mutable request endpoints

### DIFF
--- a/rest/internal/request.go
+++ b/rest/internal/request.go
@@ -81,13 +81,13 @@ func getHostFromServers(servers []rest.ServerConfig, serverIDs []string) (string
 }
 
 func buildDistributedRequestsWithOptions(request *RetryableRequest, restOptions *RESTOptions) ([]RetryableRequest, error) {
-	if strings.HasPrefix(request.RawRequest.URL, "http") {
+	if strings.HasPrefix(request.URL, "http") {
 		return []RetryableRequest{*request}, nil
 	}
 
 	if !restOptions.Distributed || len(restOptions.Settings.Servers) == 1 {
 		host, serverID := getHostFromServers(restOptions.Settings.Servers, restOptions.Servers)
-		request.URL = fmt.Sprintf("%s%s", host, request.RawRequest.URL)
+		request.URL = fmt.Sprintf("%s%s", host, request.URL)
 		request.ServerID = serverID
 		if err := request.applySettings(restOptions.Settings); err != nil {
 			return nil, err
@@ -118,7 +118,7 @@ func buildDistributedRequestsWithOptions(request *RetryableRequest, restOptions 
 		}
 
 		req := RetryableRequest{
-			URL:         fmt.Sprintf("%s%s", host, request.RawRequest.URL),
+			URL:         fmt.Sprintf("%s%s", host, request.URL),
 			ServerID:    serverID,
 			RawRequest:  request.RawRequest,
 			ContentType: request.ContentType,
@@ -217,7 +217,7 @@ func (req *RetryableRequest) applySecurity(serverConfig *rest.ServerConfig) erro
 		case rest.APIKeyInQuery:
 			value := securityScheme.Value.Value()
 			if value != nil {
-				endpoint, err := url.Parse(req.RawRequest.URL)
+				endpoint, err := url.Parse(req.URL)
 				if err != nil {
 					return err
 				}
@@ -226,8 +226,6 @@ func (req *RetryableRequest) applySecurity(serverConfig *rest.ServerConfig) erro
 				q.Add(securityScheme.Name, *securityScheme.Value.Value())
 				endpoint.RawQuery = q.Encode()
 				req.URL = endpoint.String()
-			} else {
-				req.URL = req.RawRequest.URL
 			}
 		case rest.APIKeyInCookie:
 			if securityScheme.Value != nil {

--- a/rest/mutation.go
+++ b/rest/mutation.go
@@ -62,9 +62,8 @@ func (c *RESTConnector) execProcedure(ctx context.Context, operation *schema.Mut
 
 	// 2. create and execute request
 	// 3. evaluate response selection
-	procedure.Request.URL = endpoint
 	restOptions.Settings = settings
-	httpRequest, err := c.createRequest(procedure.Request, headers, rawArgs)
+	httpRequest, err := c.createRequest(procedure.Request, endpoint, headers, rawArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/query.go
+++ b/rest/query.go
@@ -69,9 +69,8 @@ func (c *RESTConnector) execQuery(ctx context.Context, request *schema.QueryRequ
 
 	// 2. create and execute request
 	// 3. evaluate response selection
-	function.Request.URL = endpoint
 	restOptions.Settings = settings
-	httpRequest, err := c.createRequest(function.Request, headers, nil)
+	httpRequest, err := c.createRequest(function.Request, endpoint, headers, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/request.go
+++ b/rest/request.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hasura/ndc-sdk-go/utils"
 )
 
-func (c *RESTConnector) createRequest(rawRequest *rest.Request, headers http.Header, arguments map[string]any) (*internal.RetryableRequest, error) {
+func (c *RESTConnector) createRequest(rawRequest *rest.Request, endpoint string, headers http.Header, arguments map[string]any) (*internal.RetryableRequest, error) {
 	var buffer io.ReadSeeker
 	contentType := contentTypeJSON
 	bodyData, ok := arguments["body"]
@@ -66,7 +66,7 @@ func (c *RESTConnector) createRequest(rawRequest *rest.Request, headers http.Hea
 	}
 
 	request := &internal.RetryableRequest{
-		URL:         rawRequest.URL,
+		URL:         endpoint,
 		RawRequest:  rawRequest,
 		ContentType: contentType,
 		Headers:     headers,


### PR DESCRIPTION
Avoid modifying mutable request endpoints, for example, append query parameters