### PR TITLE
release non-root alpine-based image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,10 +45,18 @@ jobs:
           images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          file: Dockerfile.alpine
+          tags: ${{ steps.docker-metadata.outputs.tags }}-alpine
           labels: ${{ steps.docker-metadata.outputs.labels }}
 
       - name: Build connector definition

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,24 @@
+# build context at repo root: docker build -f Dockerfile .
+FROM golang:1.22 AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -v -o ndc-cli .
+
+# stage 2: production image
+FROM alpine:3.20.2
+
+# Copy the binary to the production image from the builder stage.
+COPY --from=builder /app/ndc-cli /ndc-cli
+
+RUN adduser -S appuser
+USER appuser
+
+ENV HASURA_CONFIGURATION_DIRECTORY=/etc/connector
+
+ENTRYPOINT ["/ndc-cli"]
+
+# Run the web service on container startup.
+CMD ["serve"]


### PR DESCRIPTION
Release a non-root alpine-based image along with the distroless image. Some derived images may need to add more advanced shell scripts.