### PR TITLE
security: percent-encode string path parameters to prevent upstream path traversal (CWE-22)

### DIFF
--- a/connector/internal/client.go
+++ b/connector/internal/client.go
@@ -428,7 +428,7 @@ func (client *HTTPClient) evalHTTPResponse(
 			http.StatusInternalServerError,
 			"failed to evaluate response",
 			map[string]any{
-				"cause": "unsupported content type " + contentType,
+				errorKeyCause: "unsupported content type " + contentType,
 			},
 		)
 	}

--- a/connector/internal/contenttype/url_encode.go
+++ b/connector/internal/contenttype/url_encode.go
@@ -687,7 +687,7 @@ func SetHeaderParameters(
 	}
 
 	explode := param.GetExplode(rest.InHeader)
-	headerValues := transformParameterItemStrings(queryParams, explode)
+	headerValues := transformParameterItemStrings(queryParams, explode, false)
 	header.Set(param.Name, strings.Join(headerValues, ","))
 }
 
@@ -714,7 +714,12 @@ func encodePathParameterValue(
 	defaultParam := queryParams.FindDefault()
 	// the param is an array or a primitive value
 	if defaultParam != nil {
-		values := defaultParam.Values()
+		// Percent-encode each individual value before joining so that style
+		// separators (",", ";", ".") are preserved while reserved characters
+		// such as "/" and ".." inside a value are escaped. This prevents
+		// path-traversal (CWE-22) where a crafted string path parameter could
+		// otherwise redirect the upstream request to an arbitrary path.
+		values := escapePathParameterValues(defaultParam.Values())
 
 		if len(values) == 0 || (len(values) == 1 && values[0] == "") {
 			switch style {
@@ -758,7 +763,7 @@ func encodePathParameterValue(
 		}
 	}
 
-	keyValues := transformParameterItemStrings(queryParams, explode)
+	keyValues := transformParameterItemStrings(queryParams, explode, true)
 
 	switch style {
 	case rest.EncodingStyleMatrix:
@@ -782,13 +787,41 @@ func encodePathParameterValue(
 	}
 }
 
-func transformParameterItemStrings(queryParams ParameterItems, explode bool) []string {
+// escapePathParameterValues percent-encodes each value individually so that it
+// is safe to substitute into a URL path. Escaping per element (rather than the
+// joined string) preserves the style separators while neutralizing reserved
+// characters such as "/" and ".." that would otherwise enable path traversal.
+func escapePathParameterValues(values []string) []string {
+	escaped := make([]string, len(values))
+	for i, v := range values {
+		escaped[i] = url.PathEscape(v)
+	}
+
+	return escaped
+}
+
+// transformParameterItemStrings flattens parameter items into key/value strings.
+// When escape is true (path parameters), each key and value is percent-encoded
+// individually to prevent path traversal; header parameters pass escape=false
+// to keep their existing raw behavior.
+func transformParameterItemStrings(
+	queryParams ParameterItems,
+	explode bool,
+	escape bool,
+) []string {
 	var headerValues []string
 
 	for _, pair := range queryParams {
 		key := pair.Keys().Format(false)
+		if escape {
+			key = url.PathEscape(key)
+		}
 
 		for _, value := range pair.Values() {
+			if escape {
+				value = url.PathEscape(value)
+			}
+
 			if explode {
 				// R=100,G=200,B=150
 				headerValues = append(headerValues, key+"="+value)

--- a/connector/internal/contenttype/url_encode_test.go
+++ b/connector/internal/contenttype/url_encode_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"path"
 	"slices"
 	"strings"
 	"testing"
@@ -1440,6 +1441,90 @@ func TestEncodePathParameters(t *testing.T) {
 				tc.param.EncodingObject,
 			)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestEncodePathParameters_PathTraversal is a regression test for CWE-22.
+//
+// A string path parameter value such as "../../../admin/secret" must NOT be
+// substituted into the path verbatim. Otherwise, after the connector joins the
+// rendered path onto the upstream base URL with path.Join (which calls
+// path.Clean), the "/" and ".." segments would collapse and redirect the
+// credentialed upstream request to an arbitrary path (e.g. /admin/secret).
+//
+// Reported by Alwin Persson (Intigriti).
+func TestEncodePathParameters_PathTraversal(t *testing.T) {
+	const (
+		operationPath = "/item/{name}"
+		paramName     = "name"
+		maliciousVal  = "../../../admin/secret"
+	)
+
+	testCases := []struct {
+		name  string
+		enc   rest.EncodingObject
+		value string
+	}{
+		{
+			name:  "simple",
+			value: maliciousVal,
+		},
+		{
+			name:  "matrix",
+			enc:   rest.EncodingObject{Style: rest.EncodingStyleMatrix},
+			value: maliciousVal,
+		},
+		{
+			name:  "label",
+			enc:   rest.EncodingObject{Style: rest.EncodingStyleLabel},
+			value: maliciousVal,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := ParameterItems{
+				{
+					keys:   []Key{},
+					values: []string{tc.value},
+				},
+			}
+
+			rendered := EncodePathParameters(operationPath, paramName, inputs, tc.enc)
+
+			// The encoded value must not reintroduce raw path separators or
+			// traversal segments into the rendered path.
+			assert.Assert(
+				t,
+				!strings.Contains(rendered, "../"),
+				"rendered path must not contain raw traversal segments, got %q",
+				rendered,
+			)
+			assert.Assert(
+				t,
+				strings.Contains(rendered, url.PathEscape(tc.value)) ||
+					strings.Contains(rendered, "%2F"),
+				"the malicious value should be percent-encoded, got %q",
+				rendered,
+			)
+
+			// Mirror upstream_setting.go: req.URL.Path = path.Join(base, rendered).
+			// Because the "/" and ".." are percent-encoded, path.Clean cannot
+			// collapse the segments, so the request stays within /item/...
+			joined := path.Join("/v1", rendered)
+			assert.Assert(
+				t,
+				strings.HasPrefix(joined, "/v1/item/"),
+				"path must stay within the intended prefix, got %q",
+				joined,
+			)
+			assert.Assert(
+				t,
+				joined != "/admin/secret" && !strings.HasSuffix(joined, "/admin/secret"),
+				"path traversal must not reach /admin/secret, got %q",
+				joined,
+			)
 		})
 	}
 }

--- a/connector/internal/request_builder.go
+++ b/connector/internal/request_builder.go
@@ -50,7 +50,7 @@ func (c *RequestBuilder) Build() (*RetryableRequest, error) {
 		return nil, schema.UnprocessableContentError(
 			"failed to evaluate URL and Headers from parameters",
 			map[string]any{
-				"cause": err.Error(),
+				errorKeyCause: err.Error(),
 			},
 		)
 	}

--- a/connector/internal/request_builder_test.go
+++ b/connector/internal/request_builder_test.go
@@ -158,11 +158,15 @@ func TestEvalURLAndHeaderParametersOAS2(t *testing.T) {
 		headers      map[string]string
 	}{
 		{
+			// CWE-22: "/" inside a single string path parameter is now
+			// percent-encoded (%2F) so it cannot traverse to a different
+			// upstream path. The value below decodes once to %2F (the raw URL
+			// holds %252F) instead of a literal slash.
 			name: "get_subject",
 			rawArguments: `{
 				"identifier": "thesauri/material/AAT.11914"
 			}`,
-			expectedURL: "/id/thesauri/material/AAT.11914",
+			expectedURL: "/id/thesauri%2Fmaterial%2FAAT.11914",
 		},
 	}
 

--- a/connector/internal/request_raw.go
+++ b/connector/internal/request_raw.go
@@ -60,7 +60,7 @@ func (rqe *RawRequestBuilder) Explain() (*schema.ExplainResponse, error) {
 	rawHeaders, err := json.Marshal(httpRequest.Headers)
 	if err != nil {
 		return nil, schema.InternalServerError("failed to encode headers", map[string]any{
-			"cause": err.Error(),
+			errorKeyCause: err.Error(),
 		})
 	}
 

--- a/connector/internal/types.go
+++ b/connector/internal/types.go
@@ -15,6 +15,10 @@ const (
 	acceptHeader               = "Accept"
 	defaultTimeoutSeconds uint = 30
 	defaultRetryDelays    uint = 1000
+
+	// keys used in structured error/response detail maps.
+	errorKeyCause   = "cause"
+	responseKeyData = "data"
 )
 
 var errRequestBodyRequired = errors.New("request body is required")
@@ -102,8 +106,8 @@ func (dr DistributedResponse[T]) ToMap() map[string]any {
 	results := make([]map[string]any, len(dr.Results))
 	for i, result := range dr.Results {
 		results[i] = map[string]any{
-			"server": result.Server,
-			"data":   result.Data,
+			"server":        result.Server,
+			responseKeyData: result.Data,
 		}
 	}
 

--- a/connector/internal/upstream_request.go
+++ b/connector/internal/upstream_request.go
@@ -31,7 +31,7 @@ func (um *UpstreamManager) BuildRequests(
 	httpOptions, err := um.parseHTTPOptionsFromArguments(operation.Arguments, rawArgs)
 	if err != nil {
 		return nil, schema.UnprocessableContentError("invalid http options", map[string]any{
-			"cause": err.Error(),
+			errorKeyCause: err.Error(),
 		})
 	}
 

--- a/connector/mutation.go
+++ b/connector/mutation.go
@@ -27,7 +27,7 @@ func (c *HTTPConnector) Mutation(
 			return nil, schema.UnprocessableContentError(
 				"invalid request_arguments in request body",
 				map[string]any{
-					"cause": err.Error(),
+					errorKeyCause: err.Error(),
 				},
 			)
 		}
@@ -71,7 +71,7 @@ func (c *HTTPConnector) MutationExplain(
 				return nil, schema.UnprocessableContentError(
 					"invalid request_arguments in request body",
 					map[string]any{
-						"cause": err.Error(),
+						errorKeyCause: err.Error(),
 					},
 				)
 			}
@@ -97,7 +97,7 @@ func (c *HTTPConnector) explainProcedure(
 	var rawArgs map[string]any
 	if err := json.Unmarshal(operation.Arguments, &rawArgs); err != nil {
 		return nil, schema.BadRequestError("failed to decode arguments", map[string]any{
-			"cause": err.Error(),
+			errorKeyCause: err.Error(),
 		})
 	}
 

--- a/connector/query.go
+++ b/connector/query.go
@@ -39,7 +39,7 @@ func (c *HTTPConnector) Query(
 			return nil, schema.UnprocessableContentError(
 				"invalid request_arguments in request body",
 				map[string]any{
-					"cause": err.Error(),
+					errorKeyCause: err.Error(),
 				},
 			)
 		}
@@ -77,7 +77,7 @@ func (c *HTTPConnector) QueryExplain(
 			return nil, schema.UnprocessableContentError(
 				"invalid request_arguments in request body",
 				map[string]any{
-					"cause": err.Error(),
+					errorKeyCause: err.Error(),
 				},
 			)
 		}
@@ -100,7 +100,7 @@ func (c *HTTPConnector) explainQuery(
 		return nil, schema.UnprocessableContentError(
 			"failed to resolve argument variables",
 			map[string]any{
-				"cause": err.Error(),
+				errorKeyCause: err.Error(),
 			},
 		)
 	}
@@ -128,7 +128,7 @@ func (c *HTTPConnector) execQuerySync(
 			Aggregates: schema.RowSetAggregates{},
 			Rows: []map[string]any{
 				{
-					"__value": result,
+					valueFieldKey: result,
 				},
 			},
 		}
@@ -170,7 +170,7 @@ func (c *HTTPConnector) execQueryAsync(
 					Aggregates: schema.RowSetAggregates{},
 					Rows: []map[string]any{
 						{
-							"__value": result,
+							valueFieldKey: result,
 						},
 					},
 				}
@@ -270,7 +270,7 @@ func (c *HTTPConnector) serializeExplainResponse(
 	rawHeaders, err := json.Marshal(req.Header)
 	if err != nil {
 		return nil, schema.InternalServerError("failed to encode headers", map[string]any{
-			"cause": err.Error(),
+			errorKeyCause: err.Error(),
 		})
 	}
 

--- a/connector/types.go
+++ b/connector/types.go
@@ -7,6 +7,13 @@ import (
 	"github.com/hasura/gotel"
 )
 
+const (
+	// valueFieldKey is the NDC field key holding a function's scalar result.
+	valueFieldKey = "__value"
+	// errorKeyCause is the key used in structured error detail maps.
+	errorKeyCause = "cause"
+)
+
 var errBuildSchemaFailed = errors.New("failed to build NDC HTTP schema")
 
 // State is the global state which is shared for every connector request.


### PR DESCRIPTION
## Summary

**CWE-22 path traversal in string path parameters.**

String path parameters were substituted into the upstream request path **without percent-encoding**. In `connector/internal/contenttype/url_encode.go`, `encodePathParameterValue` joined raw values with the style separator (default `,`, matrix `;`, label `.`), and `EncodePathParameters` spliced the result into the path template via `strings.ReplaceAll`.

Because of this, `/` and `..` inside a **string** path-parameter value survived into `req.URL.Path` and were then collapsed by `path.Join`/`path.Clean` in `connector/internal/upstream_setting.go`, redirecting the **credentialed** upstream request to an arbitrary absolute path.

Reporter's scenario — operation `/item/{name}` with value `../../../admin/secret` would resolve to `/admin/secret`, sending the connector's upstream credential to an unintended endpoint.

## Fix

Apply `url.PathEscape` to **each individual value** (and each key in the matrix/label `key=value` forms) **before joining**, so:
- legitimate style separators (`,`, `;`, `.`) are preserved, while
- reserved characters such as `/` and `.` **inside a value** are percent-encoded.

The change is confined to the **path-parameter code path**:
- Query parameters (`EncodeQueryValues` → `url.Values.Encode`) already encode correctly — **untouched**.
- `data_uri.go` (`url.PathEscape`) already encodes correctly — **untouched**.
- Integer/float/bool path params are re-serialized to a safe charset — unaffected.
- Header encoding behavior is preserved via an explicit `escape=false` flag on the shared `transformParameterItemStrings` helper.

## Verification

- Added a regression test (`TestEncodePathParameters_PathTraversal`) in `connector/internal/contenttype/url_encode_test.go` mirroring the reporter's scenario across simple/matrix/label styles: a value of `../../../admin/secret` is percent-encoded so that after `path.Join` the path stays within the intended prefix and never collapses to `/admin/secret`. **It passes.**
- Updated the existing `get_subject` OAS2 test to reflect the now-encoded slashes (`%2F`) — this case previously demonstrated the vulnerable behavior.
- `go build ./...` ✅
- `go test ./connector/...` ✅ (all pass; the unrelated `TestConnectorOAuth` integration test requires a live Hydra OAuth server on `localhost:4445` and fails identically on clean `main` — environmental, not affected by this change)
- `gofmt`/`goimports` clean on all changed files.

## Credit

Reported by **Alwin Persson (Intigriti)**.

## Traceability

Originating PromptQL thread: https://prompt.ql.app/project/hasuraql/promptql-playground/thread/22d8b1a3-f458-4652-953a-d05073bd8734

🤖 Generated with [Claude Code](https://claude.com/claude-code)